### PR TITLE
NEW UPDATE AVAILABLE TO MERGE

### DIFF
--- a/src/factions/command/InviteList.php
+++ b/src/factions/command/InviteList.php
@@ -80,7 +80,7 @@ class InviteList extends Command
         $pager->stringify();
 
         // Pager Message
-        $sender->sendMessage($pager->getHeader());
+        $sender->sendMessage($pager->getTitle());
         foreach ($pager->getOutput() as $l) $sender->sendMessage($l);
 
         return true;

--- a/src/factions/command/PermList.php
+++ b/src/factions/command/PermList.php
@@ -60,7 +60,7 @@ class PermList extends Command {
 
 		$pager->sendTitle($sender);
 
-		$sender->sendMessage(Text::titleize(Localizer::translatable($pager->getHeader(), [$pager->getPage(), $pager->getMax()])));
+		$sender->sendMessage(Text::titleize(Localizer::translatable($pager->getTitle(), [$pager->getPage(), $pager->getMax()])));
 		foreach ($pager->getOutput() as $line) {
 			$sender->sendMessage($line);
 		}

--- a/src/factions/command/PermShow.php
+++ b/src/factions/command/PermShow.php
@@ -53,7 +53,7 @@ class PermShow extends Command
         });
         $pager->stringify();
 
-        $sender->sendMessage(Text::titleize(Localizer::translatable($pager->getHeader(), [$pager->getPage(), $pager->getMax(), $faction->getName()])));
+        $sender->sendMessage(Text::titleize(Localizer::translatable($pager->getTitle(), [$pager->getPage(), $pager->getMax(), $faction->getName()])));
 
         $sender->sendMessage(Permission::getStateHeaders());
         foreach ($pager->getOutput() as $line) $sender->sendMessage($line);

--- a/src/factions/command/RelationList.php
+++ b/src/factions/command/RelationList.php
@@ -82,7 +82,7 @@ class RelationList extends Command
                 return Rel::getColor($item["relation"]) . $item["relation"] . RelationList::SEPERATOR . $item["faction"];
             });
             $pager->stringify();
-            $sender->sendMessage(Localizer::translatable($pager->getHeader(), [
+            $sender->sendMessage(Localizer::translatable($pager->getTitle(), [
                 "faction" => $faction->getName(),
                 "page" => $pager->getPage(),
                 "max" => $pager->getMax()

--- a/src/factions/command/RelationWishes.php
+++ b/src/factions/command/RelationWishes.php
@@ -66,7 +66,7 @@ class RelationWishes extends Command
             return Rel::getColor($item["relation"]) . $item["relation"] . RelationList::SEPERATOR . $item["faction"];
         });
         $pager->stringify();
-        $sender->sendMessage(Localizer::translatable($pager->getHeader(), [
+        $sender->sendMessage(Localizer::translatable($pager->getTitle(), [
             "faction" => $faction->getName(),
             "page" => $pager->getPage(),
             "max" => $pager->getMax()


### PR DESCRIPTION
Hi, so I have recently discovered with this new update, /f perm list got messed up along with a few other commands. 
But this PR basically fixes /f perm list, and other commands that were caused by this issue, as the original developer probably forgot to add / fix this change.
This PR should fix /f perm list.
the $pager->getHeader() code should be renamed to $pager->getTitle(), as getHeader() function no longer exists, and was original renamed to getTitle().
Please test this change before merging, thanks.