### PR TITLE
Some bugs/errors fix

### DIFF
--- a/src/factions/engine/MainEngine.php
+++ b/src/factions/engine/MainEngine.php
@@ -204,8 +204,8 @@ class MainEngine extends Engine {
 				$world = $plot->getLevel();
 
 				// Can't claim a plot in this level (not specified in config)
-				if (!in_array($world->getName(), Gameplay::get("worlds-claiming-enabled", []), true)) {
-					$worldName = $world->getName();
+				if (!in_array($world->getFolderName(), Gameplay::get("worlds-claiming-enabled", []), true)) {
+					$worldName = $world->getFolderName();
 					$player->sendMessage(Localizer::translatable("claiming-disabled-in-world", [$worldName]));
 					return false;
 				}

--- a/src/factions/engine/MainEngine.php
+++ b/src/factions/engine/MainEngine.php
@@ -320,7 +320,7 @@ class MainEngine extends Engine {
 			$player->sendMessage(Localizer::translatable("no-powerloss-due-to-faction"));
 			return;
 		}
-		if (!in_array($player->getLevel()->getName(), Gameplay::get("worlds-power-loss-enabled", []), true)) {
+		if (!in_array($player->getLevel()->getFolderName(), Gameplay::get("worlds-power-loss-enabled", []), true)) {
 			$player->sendMessage(Localizer::translatable("no-powerloss-due-to-world"));
 			return;
 		}

--- a/src/factions/manager/Plots.php
+++ b/src/factions/manager/Plots.php
@@ -264,13 +264,14 @@ class Plots
     public static function isBorderPlot(Plot $plot): bool
     {
         $faction = $plot->getOwnerFaction();
-        $nearby = new Plot($plot->x + 1, $plot->z, $plot);
+        $level = $plot->getLevel();
+        $nearby = new Plot($plot->x + 1, $plot->z, $level);
         if ($faction !== $nearby->getOwnerFaction()) return true;
-        $nearby = new Plot($plot->x - 1, $plot->z, $plot);
+        $nearby = new Plot($plot->x - 1, $plot->z, $level);
         if ($faction !== $nearby->getOwnerFaction()) return true;
-        $nearby = new Plot($plot->x, $plot->z + 1, $plot);
+        $nearby = new Plot($plot->x, $plot->z + 1, $level);
         if ($faction !== $nearby->getOwnerFaction()) return true;
-        $nearby = new Plot($plot->x, $plot->z - 1, $plot);
+        $nearby = new Plot($plot->x, $plot->z - 1, $level);
         if ($faction !== $nearby->getOwnerFaction()) return true;
         return false;
     }

--- a/src/factions/manager/Plots.php
+++ b/src/factions/manager/Plots.php
@@ -76,7 +76,7 @@ class Plots
     public static function hash(Position $pos): string 
     {
         //if(!$pos->level) return md5(microtime(true));
-        return $pos->x . ":" . $pos->z . ":" . $pos->level->getName();
+        return $pos->x . ":" . $pos->z . ":" . $pos->level->getFolderName();
     }
 
 

--- a/src/factions/manager/Plots.php
+++ b/src/factions/manager/Plots.php
@@ -186,11 +186,11 @@ class Plots
      */
     public static function unclaim(Plot $plot, IMember $player = null, $silent = false): bool
     {
+        if (!$player) $player = $faction->getLeader();
         if (($id = $plot->getOwnerId()) !== Faction::NONE) {
             if (($faction = Factions::getById($id)) instanceof Faction) {
                 if (!$silent) {
-                    $leader = $faction->getLeader();
-                    FactionsPE::get()->getServer()->getPluginManager()->callEvent($e = new LandChangeEvent($faction, $leader, $plot, LandChangeEvent::UNCLAIM));
+                    FactionsPE::get()->getServer()->getPluginManager()->callEvent($e = new LandChangeEvent($faction, $player, $plot, LandChangeEvent::UNCLAIM));
                     if ($e->isCancelled()) return false;
                     unset(self::$plots[$plot->hash()]);
                     FactionsPE::get()->getDataProvider()->deletePlot($plot);


### PR DESCRIPTION
This will fix:
- Call to a member function getLevel() on null" (EXCEPTION) in "plugins/FactionsPE_pr-16.phar/src/factions/manager/Plots" at line 227
because $level->getName() return World display name and $level->getLevelByName() uses folder name
- Argument 3 passed to factions\e
ntity\Plot::__construct() must be an instance of pocketmine\level\Level or null,
instance of factions\entity\Plot given, called in /root/test2/StartPmmp/plugins
/FactionsPE-reborn/src/factions/manager/Plots.php on line 267" (EXCEPTION) in "FactionsPE-reborn/src/factions/entity/Plot" at line 39